### PR TITLE
fixes function names in ZeroDarkThirty README.md

### DIFF
--- a/workshops/03-coercion-and-truthiness/05-zero-dark-thirty/README.md
+++ b/workshops/03-coercion-and-truthiness/05-zero-dark-thirty/README.md
@@ -2,15 +2,15 @@
 
 Write a function `zeroDarkThirty` that accepts a number as an arguemnt.
 
-`mySlice` should return a number with all of the zeroes removed:
+`zeroDarkThirty` should return a number with all of the zeroes removed:
 
 ```javascript
-removeZero(102302) // => 1232
-removeZero(606.203) // => 66.23
+zeroDarkThirty(102302) // => 1232
+zeroDarkThirty(606.203) // => 66.23
 ```
 
 If the number 0 is passed in as the argument, return [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
 
 ```javascript
-removeZero(0) // => NaN
+zeroDarkThirty(0) // => NaN
 ```


### PR DESCRIPTION
I noticed 3 different function names in the `README.md` file.  Looks like they were all meant to be `zeroDarkThirty()`.